### PR TITLE
Vite Helper Updates 

### DIFF
--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -10,6 +10,7 @@ class SimulatorController < ApplicationController
   before_action :set_user_project, only: %i[update edit update_image]
   before_action :check_view_access, only: %i[show embed get_data]
   before_action :check_edit_access, only: %i[edit update update_image]
+  before_action :set_version
   skip_before_action :verify_authenticity_token, only: %i[get_data create update verilog_cv]
   after_action :allow_iframe, only: %i[embed]
   after_action :allow_iframe_lti, only: %i[show], constraints: lambda {
@@ -127,6 +128,12 @@ class SimulatorController < ApplicationController
   end
 
   private
+
+    def set_version
+      version_param = params[:simver]
+      allowed_versions = ['v1', 'v2'] # Will add more versions as needed
+      @version = allowed_versions.include?(version_param&.downcase) ? version_param.downcase : 'v1'
+    end
 
     def allow_iframe
       response.headers.except! "X-Frame-Options"

--- a/app/helpers/vite_helper.rb
+++ b/app/helpers/vite_helper.rb
@@ -1,0 +1,31 @@
+# app/helpers/vite_helper.rb
+
+module ViteHelper
+  def vite_javascript_tag(*_names,
+                          type: "module",                         
+                          skip_preload_tags: false,
+                          skip_style_tags: false,
+                          crossorigin: "anonymous",
+                          media: "screen",
+                          **options)
+    # Determine the version from the query parameter
+    version = params[:simv] || "v2" # Default to v1 if version query parameter is not provided
+
+    # Construct the path based on the simv
+    path = "/#{version}/vite/entrypoints/simulator.js"
+
+    # Generate the JavaScript tag
+    tag = javascript_include_tag(path, crossorigin: crossorigin, type: type, extname: false, **options)
+
+    # Generate preload tag if necessary
+    tag << vite_preload_tag(path, crossorigin: crossorigin, **options) unless skip_preload_tags
+
+    # Set extname option to false for Rails version >= 7
+    options[:extname] = false if Rails::VERSION::MAJOR >= 7
+
+    # Generate stylesheet link tag if necessary
+    tag << stylesheet_link_tag(*entries.fetch(:stylesheets), media: media, **options) unless skip_style_tags
+
+    tag  # Return the generated tag
+  end
+end

--- a/app/views/layouts/simulator.html.erb
+++ b/app/views/layouts/simulator.html.erb
@@ -5,9 +5,11 @@
     <script>window.locale = "<%= I18n.locale %>"</script>
     <script src="/js/pace.js"></script>
     <%= vite_client_tag %>
-    <%= vite_javascript_tag "jquery" %>
-    <%= vite_javascript_tag "bootstrap" %>
-    <%= vite_javascript_tag "simulator" %>
+    <%= vite_javascript_tag "jquery", version: params[:simver] %>
+    <%= vite_javascript_tag "bootstrap", version: params[:simver] %>
+    <%= vite_javascript_tag "simulator", version: params[:simver] %>
+
+
     <%= favicon_link_tag "favicon.ico" %>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <%= render "layouts/google_analytics" %>


### PR DESCRIPTION


#### Describe the changes you have made in this PR -

In this PR, I've made updates to the Vite helper to accommodate vite_javascript_tag. 

Added a `set_version` method as a `before_action`
Updated the `vite_javascript_tag` method in the Vite helper
Updated the usage of `vite_javascript_tag` in relevant views

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
